### PR TITLE
Playing with inertia when calculating percentage change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "2022-12-07-ios-slider",
+  "name": "2022-12-07-ios-16-slider",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "2022-12-07-ios-slider",
+      "name": "2022-12-07-ios-16-slider",
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.0.13",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,9 +57,17 @@ export default function Page() {
                 onPointerEnter={() => setHovered(true)}
                 onPointerLeave={() => setHovered(false)}
                 onPan={(event, info) => {
-                  let deltaInPercent = info.delta.x / bounds.width;
-                  let newPercent = clamp(progress.get() + deltaInPercent, 0, 1);
-                  progress.set(newPercent);
+                  const previousPercent = progress.get();
+                  const deltaInPercent = info.delta.x / bounds.width;
+                  const difference =
+                    previousPercent + deltaInPercent - previousPercent;
+                  const scalingFactor = 1 + Math.abs(difference) * 6;
+                  const newPercentWithInertia = clamp(
+                    previousPercent + deltaInPercent * scalingFactor,
+                    0,
+                    1
+                  );
+                  progress.set(newPercentWithInertia);
                 }}
                 style={{ height: height + buffer }}
                 className="flex items-center justify-center relative touch-none grow-0"


### PR DESCRIPTION
Adapted the percentage change calculation to add in the concept of inertia.

- I did this with the help of ChatGPT, which got me 90% of the way there.
- The inertia value can be changed by updating the value the difference is multiplied by. I've found that `6` has a nice feel to it, at least on desktop with a mouse. Further testing is required for mobile.
- This is to emulate something I've seen on iOS sliders before(although can't find a worthwhile example at this moment), which change their position depending on the movement speed of the users finger.
- This can help users make an update without having to swipe across the whole screen.

## Chat GPT conversation
![chatgpt-slider-inertia-1](https://user-images.githubusercontent.com/811889/219990557-0fff3383-3526-4cb6-bb18-e8dca638b645.png)
![chatgpt-slider-inertia-2](https://user-images.githubusercontent.com/811889/219990560-3a1772f2-eaf5-4d70-ac28-c4110077859a.png)
